### PR TITLE
Measure test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[paths]
+source =
+   src
+   */site-packages
+
+[run]
+branch = true
+parallel = true
+source =
+    src/scene_synthesizer
+    test
+
+[report]
+show_missing = true
+precision = 1
+

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -4,7 +4,7 @@
 
 From the root directory of the repo, run the following:
 ```
-python -m pytest -n auto tests/
+python -m pytest
 ```
 
 ## Generate Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,5 +35,10 @@ import_heading_localfolder = "Local Folder"
 line_length = 100
 
 [tool.pytest.ini_options]
+# for more details on configuration, see
+# https://github.com/pytest-dev/pytest-cov/tree/4732d50f2322a6e0ea480a6c400fbc96f78283bb/examples/src-layout
 norecursedirs = [".git", ".venv", "deprecated", "dist"]
 python_files = ["*_test.py"]
+testpaths = ["tests"]
+addopts = "-n auto --cov-config=.coveragerc --cov=scene_synthesizer --cov-report html"
+


### PR DESCRIPTION
I was interested in measuring the test coverage of the project and configured it such that for each pytest call, the test coverage will be reported in `htmlcov/index.html` automatically. In addition, I added the option `-n auto` by default, so that a call to

```bash
python -m pytest
```

is sufficient to parallelize test execution and measure coverage.

Related to #4 