### PR TITLE
[BugFix] fix bug of joint relationship process in USDAsset._as_trimesh_scene()

### DIFF
--- a/src/scene_synthesizer/assets.py
+++ b/src/scene_synthesizer/assets.py
@@ -1157,6 +1157,8 @@ class USDAsset(Asset):
             # Child of root path can be added immediately
             if parent_path.pathString != "/":
                 for x, y in joints:
+                    if joints[(x, y)] == "reversed":
+                        continue
                     if y == xform_path:
                         # since they could be connected via a joint it, we will first check whether the other body is part of the scene
                         log.debug(f"Found relevant joint constraint: {x} <-> {y}")


### PR DESCRIPTION
### Why
Previously, joints were being processed twice due to USD's bidirectional nature, causing incorrect hierarchy issues. This fix ensures consistent scene graph construction. So I skip processing when encountering the reversed entry
USD joints are bidirectional (A-B is same as B-A).
```python
                joints[(body_0, body_1)] = joint_prim

                joints[(body_1, body_0)] = "reversed"
```
[here](https://github.com/NVlabs/scene_synthesizer/blob/ce4b40e7117d64e6c7a17461593d7f1beb264980/src/scene_synthesizer/assets.py#L1118-L1120C19)